### PR TITLE
[Feat] 회원가입, 사용자 정보 수정 관련 API들 추가 및 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/prisma/migrations/20250510053022_/migration.sql
+++ b/prisma/migrations/20250510053022_/migration.sql
@@ -1,0 +1,50 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[login_id]` on the table `user` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[name]` on the table `user` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateEnum
+CREATE TYPE "Gender" AS ENUM ('MALE', 'FEMALE');
+
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "birthday" TIMESTAMP(3),
+ADD COLUMN     "gender" "Gender",
+ADD COLUMN     "login_id" TEXT,
+ADD COLUMN     "profile_image_url" TEXT;
+
+-- CreateTable
+CREATE TABLE "category" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "category_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user-category" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+
+    CONSTRAINT "user-category_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "category_name_key" ON "category"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user-category_userId_categoryId_key" ON "user-category"("userId", "categoryId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_login_id_key" ON "user"("login_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_name_key" ON "user"("name");
+
+-- AddForeignKey
+ALTER TABLE "user-category" ADD CONSTRAINT "user-category_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user-category" ADD CONSTRAINT "user-category_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250510053342_/migration.sql
+++ b/prisma/migrations/20250510053342_/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Made the column `birthday` on table `user` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `gender` on table `user` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `login_id` on table `user` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "user" ALTER COLUMN "birthday" SET NOT NULL,
+ALTER COLUMN "gender" SET NOT NULL,
+ALTER COLUMN "login_id" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,8 +15,12 @@ datasource db {
 
 model User {
   id           Int       @id @default(autoincrement())
-  name         String
+  loginId      String    @unique @map("login_id")
+  name         String    @unique
   email        String    @unique
+  gender       Gender
+  birthday     DateTime
+  profileImageUrl String? @map("profile_image_url")
   password     String
   refreshToken String?   @map("refresh_token")
   createdAt    DateTime  @default(now()) @map("created_at")
@@ -26,6 +30,7 @@ model User {
   paragraphLikes        ParagraphLike[]
   bookLikes    BookLike[]
   userBooks    UserBook[]
+  userCategories UserCategory[]
 
   @@map("user")
 }
@@ -57,6 +62,15 @@ model Paragraph {
   likes        ParagraphLike[]
 
   @@map("paragraph")
+}
+
+model Category {
+  id           Int       @id @default(autoincrement())
+  name         String    @unique
+
+  favoredBy   UserCategory[]
+
+  @@map("category")
 }
 
 model ParagraphLike {
@@ -93,4 +107,21 @@ model UserBook {
 
   @@unique([userId, bookId])
   @@map("user-book")
+}
+
+model UserCategory {
+  id      Int  @id @default(autoincrement())
+  userId  Int
+  categoryId  Int
+
+  user    User @relation(fields: [userId], references: [id])
+  category    Category @relation(fields: [categoryId], references: [id])
+
+  @@unique([userId, categoryId])
+  @@map("user-category")
+}
+
+enum Gender{
+  MALE    @map("MALE")
+  FEMALE  @map("FEMALE")
 }

--- a/src/auth/auth.repository.ts
+++ b/src/auth/auth.repository.ts
@@ -11,12 +11,20 @@ export class AuthRepository {
   async createUser(data: SignUpData): Promise<UserBaseInfo> {
     return this.prisma.user.create({
       data: {
+        loginId: data.loginId,
+        gender: data.gender,
+        birthday: data.birthday,
+        profileImageUrl: data.profileImageUrl,
         email: data.email,
         password: data.password,
         name: data.name,
       },
       select: {
         id: true,
+        loginId: true,
+        gender: true,
+        birthday: true,
+        profileImageUrl: true,
         email: true,
         password: true,
         name: true,
@@ -31,6 +39,10 @@ export class AuthRepository {
         id: id,
       },
       data: {
+        loginId: data.loginId,
+        gender: data.gender,
+        birthday: data.birthday,
+        profileImageUrl: data.profileImageUrl,
         email: data.email,
         password: data.password,
         name: data.name,
@@ -38,6 +50,10 @@ export class AuthRepository {
       },
       select: {
         id: true,
+        loginId: true,
+        gender: true,
+        birthday: true,
+        profileImageUrl: true,
         email: true,
         password: true,
         name: true,
@@ -54,6 +70,10 @@ export class AuthRepository {
       },
       select: {
         id: true,
+        loginId: true,
+        gender: true,
+        birthday: true,
+        profileImageUrl: true,
         email: true,
         password: true,
         name: true,
@@ -70,6 +90,50 @@ export class AuthRepository {
       },
       select: {
         id: true,
+        loginId: true,
+        gender: true,
+        birthday: true,
+        profileImageUrl: true,
+        email: true,
+        password: true,
+        name: true,
+        refreshToken: true,
+      },
+    });
+  }
+
+  async getUserByLoginId(loginId: string): Promise<UserBaseInfo | null> {
+    return this.prisma.user.findUnique({
+      where: {
+        loginId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        loginId: true,
+        gender: true,
+        birthday: true,
+        profileImageUrl: true,
+        email: true,
+        password: true,
+        name: true,
+        refreshToken: true,
+      },
+    });
+  }
+
+  async getUserByName(name: string): Promise<UserBaseInfo | null> {
+    return this.prisma.user.findUnique({
+      where: {
+        name,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        loginId: true,
+        gender: true,
+        birthday: true,
+        profileImageUrl: true,
         email: true,
         password: true,
         name: true,

--- a/src/auth/auth.repository.ts
+++ b/src/auth/auth.repository.ts
@@ -18,6 +18,11 @@ export class AuthRepository {
         email: data.email,
         password: data.password,
         name: data.name,
+        userCategories: {
+          create: data.interestCategories.map((categoryId) => ({
+            categoryId,
+          })),
+        },
       },
       select: {
         id: true,
@@ -39,9 +44,9 @@ export class AuthRepository {
         id: id,
       },
       data: {
-        loginId: data.loginId,
-        gender: data.gender,
-        birthday: data.birthday,
+        loginId: data.loginId ?? undefined,
+        gender: data.gender ?? undefined,
+        birthday: data.birthday ?? undefined,
         profileImageUrl: data.profileImageUrl,
         email: data.email,
         password: data.password,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -23,8 +23,16 @@ export class AuthService {
   ) {}
 
   async signUp(payload: SignUpPayload): Promise<Tokens> {
-    const user = await this.authRepository.getUserByEmail(payload.email);
-    if (user) {
+    const loginId = await this.authRepository.getUserByLoginId(payload.loginId);
+    if (loginId) {
+      throw new ConflictException('이미 사용중인 로그인 ID입니다.');
+    }
+    const name = await this.authRepository.getUserByName(payload.name);
+    if (name) {
+      throw new ConflictException('이미 사용중인 닉네임입니다.');
+    }
+    const email = await this.authRepository.getUserByEmail(payload.email);
+    if (email) {
       throw new ConflictException('이미 사용중인 이메일입니다.');
     }
 
@@ -33,6 +41,10 @@ export class AuthService {
     );
 
     const inputData: SignUpData = {
+      loginId: payload.loginId,
+      gender: payload.gender,
+      birthday: payload.birthday,
+      profileImageUrl: payload.profileImageUrl,
       email: payload.email,
       password: hashedPassword,
       name: payload.name,
@@ -44,11 +56,10 @@ export class AuthService {
   }
 
   async login(payload: LoginPayload): Promise<Tokens> {
-    const user = await this.authRepository.getUserByEmail(payload.email);
+    const user = await this.authRepository.getUserByLoginId(payload.loginId);
     if (!user) {
-      throw new NotFoundException('존재하지 않는 이메일입니다.');
+      throw new NotFoundException('존재하지 않는 로그인 ID입니다.');
     }
-
     const isPasswordMatch = await this.passwordService.validatePassword(
       payload.password,
       user.password,

--- a/src/auth/payload/login.payload.ts
+++ b/src/auth/payload/login.payload.ts
@@ -1,13 +1,13 @@
-import { IsEmail, IsString } from 'class-validator';
+import { IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginPayload {
-  @IsEmail()
+  @IsString()
   @ApiProperty({
-    description: '이메일',
+    description: '로그인 ID',
     type: String,
   })
-  email!: string;
+  loginId!: string;
 
   @IsString()
   @ApiProperty({

--- a/src/auth/payload/sign-up.payload.ts
+++ b/src/auth/payload/sign-up.payload.ts
@@ -1,13 +1,20 @@
-import { IsEmail, IsString } from 'class-validator';
+import { IsDate, IsEmail, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Gender as PrismaGender } from '@prisma/client';
+import { Transform } from 'class-transformer';
+
+export enum GenderEnum {
+  MALE = 'MALE',
+  FEMALE = 'FEMALE',
+}
 
 export class SignUpPayload {
-  @IsEmail()
+  @IsString()
   @ApiProperty({
-    description: '이메일',
+    description: '로그인 ID',
     type: String,
   })
-  email!: string;
+  loginId!: string;
 
   @IsString()
   @ApiProperty({
@@ -18,8 +25,36 @@ export class SignUpPayload {
 
   @IsString()
   @ApiProperty({
-    description: '이름',
+    description: '닉네임',
     type: String,
   })
   name!: string;
+
+  @IsEmail()
+  @ApiProperty({
+    description: '이메일',
+    type: String,
+  })
+  email!: string;
+
+  @ApiProperty({
+    description: '성별',
+    enum: GenderEnum,
+  })
+  gender!: PrismaGender;
+
+  @IsDate()
+  @ApiProperty({
+    description: '생년월일',
+    type: Date,
+  })
+  birthday!: Date;
+
+  @IsString()
+  @ApiProperty({
+    description: '프로필 이미지 URL',
+    type: String,
+    required: false,
+  })
+  profileImageUrl?: string | null;
 }

--- a/src/auth/payload/sign-up.payload.ts
+++ b/src/auth/payload/sign-up.payload.ts
@@ -1,7 +1,15 @@
-import { IsDate, IsEmail, IsString } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsDate,
+  IsEmail,
+  IsString,
+  IsEnum,
+  IsOptional,
+  IsArray,
+  IsInt,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Gender as PrismaGender } from '@prisma/client';
-import { Transform } from 'class-transformer';
+import { Type } from 'class-transformer';
 
 export enum GenderEnum {
   MALE = 'MALE',
@@ -25,6 +33,13 @@ export class SignUpPayload {
 
   @IsString()
   @ApiProperty({
+    description: '비밀번호 확인',
+    type: String,
+  })
+  passwordConfirm!: string;
+
+  @IsString()
+  @ApiProperty({
     description: '닉네임',
     type: String,
   })
@@ -37,6 +52,7 @@ export class SignUpPayload {
   })
   email!: string;
 
+  @IsEnum(GenderEnum)
   @ApiProperty({
     description: '성별',
     enum: GenderEnum,
@@ -44,17 +60,26 @@ export class SignUpPayload {
   gender!: PrismaGender;
 
   @IsDate()
+  @Type(() => Date)
   @ApiProperty({
     description: '생년월일',
     type: Date,
   })
   birthday!: Date;
 
-  @IsString()
-  @ApiProperty({
-    description: '프로필 이미지 URL',
-    type: String,
-    required: false,
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: '프로필 이미지',
+    type: 'string',
+    format: 'binary',
   })
-  profileImageUrl?: string | null;
+  profileImage?: string;
+
+  @IsArray()
+  @IsInt({ each: true })
+  @ApiProperty({
+    description: '관심 카테고리',
+    type: [Number],
+  })
+  interestCategories!: number[];
 }

--- a/src/auth/type/sign-up-data.type.ts
+++ b/src/auth/type/sign-up-data.type.ts
@@ -1,4 +1,10 @@
+import { Gender } from '@prisma/client';
+
 export type SignUpData = {
+  loginId: string;
+  gender: Gender;
+  birthday: Date;
+  profileImageUrl?: string | null;
   email: string;
   password: string;
   name: string;

--- a/src/auth/type/sign-up-data.type.ts
+++ b/src/auth/type/sign-up-data.type.ts
@@ -8,4 +8,5 @@ export type SignUpData = {
   email: string;
   password: string;
   name: string;
+  interestCategories: number[];
 };

--- a/src/auth/type/update-user-data.type.ts
+++ b/src/auth/type/update-user-data.type.ts
@@ -1,12 +1,13 @@
 import { Gender } from '@prisma/client';
 
 export type UpdateUserData = {
-  loginId?: string;
-  birthday?: Date;
-  gender?: Gender;
+  loginId?: string | null;
+  birthday?: Date | null;
+  gender?: Gender | null;
   profileImageUrl?: string | null;
   email?: string;
   password?: string;
   name?: string;
   refreshToken?: string | null;
+  interestCategories?: number[] | null;
 };

--- a/src/auth/type/update-user-data.type.ts
+++ b/src/auth/type/update-user-data.type.ts
@@ -1,4 +1,10 @@
+import { Gender } from '@prisma/client';
+
 export type UpdateUserData = {
+  loginId?: string;
+  birthday?: Date;
+  gender?: Gender;
+  profileImageUrl?: string | null;
   email?: string;
   password?: string;
   name?: string;

--- a/src/auth/type/user-base-info.type.ts
+++ b/src/auth/type/user-base-info.type.ts
@@ -1,5 +1,11 @@
+import { Gender } from '@prisma/client';
+
 export type UserBaseInfo = {
   id: number;
+  loginId: string;
+  gender: Gender;
+  birthday: Date;
+  profileImageUrl?: string | null;
   email: string;
   password: string;
   name: string;

--- a/src/book/book.service.ts
+++ b/src/book/book.service.ts
@@ -51,6 +51,7 @@ export class BookService {
 
     if (coverImageFile) {
       const { data, error } = await this.supabaseService.uploadImage(
+        'book-covers',
         coverImageFile.originalname,
         coverImageFile.buffer,
       );
@@ -58,7 +59,7 @@ export class BookService {
         throw new BadRequestException('이미지 업로드 실패');
       }
       coverImageUrl = data?.path
-        ? this.supabaseService.getPublicUrl(data.path)
+        ? this.supabaseService.getPublicUrl('book-covers', data.path)
         : undefined;
     }
 
@@ -123,7 +124,10 @@ export class BookService {
     if (coverImageFile) {
       // 기존 표지 이미지가 있다면 Supabase에서 삭제
       if (book.coverImageUrl) {
-        await this.supabaseService.deleteImage(book.coverImageUrl);
+        await this.supabaseService.deleteImage(
+          'book-covers',
+          book.coverImageUrl,
+        );
       }
 
       // Supabase 업로드 실행 전, 파일 이름과 버퍼 확인
@@ -132,6 +136,7 @@ export class BookService {
 
       // 새 표지 이미지 업로드
       const { data, error } = await this.supabaseService.uploadImage(
+        'book-covers',
         coverImageFile.originalname,
         coverImageFile.buffer,
       );
@@ -142,7 +147,7 @@ export class BookService {
       }
 
       coverImageUrl = data?.path
-        ? this.supabaseService.getPublicUrl(data.path)
+        ? this.supabaseService.getPublicUrl('book-covers', data.path)
         : undefined;
     }
 

--- a/src/book/payload/patch-update-book.payload.ts
+++ b/src/book/payload/patch-update-book.payload.ts
@@ -1,9 +1,11 @@
 import { IsString, IsOptional } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 
 export class PatchUpdateBookPayload {
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => (value === '' ? undefined : value))
   @ApiPropertyOptional({
     description: '책 제목',
     type: String,
@@ -12,6 +14,7 @@ export class PatchUpdateBookPayload {
 
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => (value === '' ? undefined : value))
   @ApiPropertyOptional({
     description: '책 저자',
     type: String,

--- a/src/common/services/supabase.service.ts
+++ b/src/common/services/supabase.service.ts
@@ -16,31 +16,48 @@ export class SupabaseService {
     return this.supabase;
   }
 
-  async uploadImage(fileName: string, fileBuffer: Buffer) {
+  // ✅ Bucket을 인자로 받도록 수정
+  async uploadImage(bucket: string, fileName: string, fileBuffer: Buffer) {
     return await this.supabase.storage
-      .from(process.env.NEXT_PUBLIC_STORAGE_BUCKET!)
+      .from(bucket)
       .upload(fileName, fileBuffer, { upsert: true });
   }
 
-  async deleteImage(fileName: string) {
-    return await this.supabase.storage
-      .from(process.env.NEXT_PUBLIC_STORAGE_BUCKET!)
-      .remove([fileName]);
+  async deleteImage(bucket: string, fileName: string) {
+    return await this.supabase.storage.from(bucket).remove([fileName]);
   }
 
-  getPublicUrl(path: string): string {
+  getPublicUrl(bucket: string, path: string): string {
     return this.joinUrlParts(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       'storage/v1/object/public',
-      process.env.NEXT_PUBLIC_STORAGE_BUCKET!,
+      bucket,
       path,
     );
   }
 
+  async copyImage(bucket: string, fromPath: string, toPath: string) {
+    return await this.supabase.storage.from(bucket).copy(fromPath, toPath);
+  }
+
   private joinUrlParts(...parts: string[]): string {
     return parts
-      .map((part) => part.replace(/^\/+|\/+$/g, '')) // 각 부분의 앞뒤 슬래시 제거
+      .map((part) => part.replace(/^\/+|\/+$/g, ''))
       .join('/')
-      .replace(/\/{2,}/g, '/'); // 혹시 모를 중복 슬래시 제거
+      .replace(/\/{2,}/g, '/');
   }
+}
+
+export function extractFilePathFromPublicUrl(publicUrl: string): string | null {
+  const marker = '/storage/v1/object/public/';
+  const index = publicUrl.indexOf(marker);
+
+  if (index === -1) return null;
+
+  const afterMarker = publicUrl.substring(index + marker.length); // bucket/path/to/file.jpg
+  const firstSlash = afterMarker.indexOf('/');
+
+  if (firstSlash === -1) return null;
+
+  return afterMarker.substring(firstSlash + 1); // path/to/file.jpg
 }

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -2,7 +2,6 @@ import { ApiProperty } from '@nestjs/swagger';
 import { UserData } from '../type/user-data.type';
 import { Gender as PrismaGender } from '@prisma/client';
 import { GenderEnum } from '../../auth/payload/sign-up.payload';
-import { Transform } from 'class-transformer';
 
 export class UserDto {
   @ApiProperty({

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -1,5 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UserData } from '../type/user-data.type';
+import { Gender as PrismaGender } from '@prisma/client';
+import { GenderEnum } from '../../auth/payload/sign-up.payload';
+import { Transform } from 'class-transformer';
 
 export class UserDto {
   @ApiProperty({
@@ -7,6 +10,30 @@ export class UserDto {
     type: Number,
   })
   id!: number;
+
+  @ApiProperty({
+    description: '로그인 ID',
+    type: String,
+  })
+  loginId!: string;
+
+  @ApiProperty({
+    description: '성별',
+    enum: GenderEnum,
+  })
+  gender!: PrismaGender;
+
+  @ApiProperty({
+    description: '생년월일',
+    type: Date,
+  })
+  birthday!: Date;
+
+  @ApiProperty({
+    description: '프로필 이미지 URL',
+    type: String,
+  })
+  profileImageUrl?: string | null;
 
   @ApiProperty({
     description: '이메일',
@@ -23,6 +50,10 @@ export class UserDto {
   static from(data: UserData): UserDto {
     return {
       id: data.id,
+      loginId: data.loginId,
+      gender: data.gender,
+      birthday: data.birthday,
+      profileImageUrl: data.profileImageUrl,
       email: data.email,
       name: data.name,
     };

--- a/src/user/payload/update-user.payload.ts
+++ b/src/user/payload/update-user.payload.ts
@@ -1,20 +1,109 @@
-import { IsEmail, IsOptional, IsString } from 'class-validator';
+import {
+  IsDate,
+  IsEmail,
+  IsOptional,
+  IsString,
+  IsEnum,
+  IsArray,
+  IsInt,
+  IsBoolean,
+} from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { GenderEnum } from 'src/auth/payload/sign-up.payload';
+import { Gender as PrismaGender } from '@prisma/client';
+import { Type, Transform } from 'class-transformer';
 
 export class UpdateUserPayload {
   @IsOptional()
+  @IsString()
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @ApiPropertyOptional({
+    description: '로그인 ID',
+    type: String,
+  })
+  loginId?: string | null;
+
+  @IsOptional()
+  @IsString()
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @ApiPropertyOptional({
+    description: '닉네임',
+    type: String,
+  })
+  name?: string | null;
+
+  @IsOptional()
   @IsEmail()
+  @Transform(({ value }) => (value === '' ? undefined : value))
   @ApiPropertyOptional({
     description: '이메일',
     type: String,
   })
   email?: string | null;
 
+  @IsEnum(GenderEnum)
   @IsOptional()
-  @IsString()
+  @Transform(({ value }) => (value === '' ? undefined : value))
   @ApiPropertyOptional({
-    description: '이름',
-    type: String,
+    description: '성별',
+    enum: GenderEnum,
   })
-  name?: string | null;
+  gender?: PrismaGender | null;
+
+  @IsDate()
+  @IsOptional()
+  @Type(() => Date)
+  @Transform(({ value }) => {
+    if (!value) return undefined;
+    const date = new Date(value);
+    return isNaN(date.getTime()) ? undefined : date;
+  })
+  @ApiPropertyOptional({
+    description: '생년월일',
+    type: Date,
+  })
+  birthday?: Date | null;
+
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: '프로필 이미지',
+    type: 'string',
+    format: 'binary',
+  })
+  profileImage?: Express.Multer.File;
+
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => {
+    if (value === '' || value === undefined || value === null) return undefined;
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'string') return value.toLowerCase() === 'true';
+    return Boolean(value);
+  })
+  @ApiPropertyOptional({
+    description: '기본 프로필 이미지로 변경 여부',
+    type: Boolean,
+  })
+  removeProfileImage?: boolean;
+
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
+  @Transform(({ value }) => {
+    if (!value) return undefined;
+
+    const values = Array.isArray(value)
+      ? value
+      : typeof value === 'string' && value.includes(',')
+        ? value.split(',')
+        : [value];
+
+    return values.map((v: any) => parseInt(v, 10));
+  })
+  @ApiPropertyOptional({
+    description: '관심 카테고리 ID',
+    type: [Number],
+    isArray: true,
+  })
+  interestCategories?: number[] | null;
 }

--- a/src/user/type/user-data.type.ts
+++ b/src/user/type/user-data.type.ts
@@ -1,5 +1,11 @@
+import { Gender } from '@prisma/client';
+
 export type UserData = {
   id: number;
+  loginId: string;
+  gender: Gender;
+  birthday: Date;
+  profileImageUrl?: string | null;
   email: string;
   name: string;
 };

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -8,6 +8,8 @@ import {
   ParseIntPipe,
   Patch,
   UseGuards,
+  UseInterceptors,
+  UploadedFile,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import {
@@ -15,6 +17,7 @@ import {
   ApiNoContentResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiConsumes,
 } from '@nestjs/swagger';
 import { UserDto } from './dto/user.dto';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
@@ -22,6 +25,7 @@ import { UpdateUserPayload } from './payload/update-user.payload';
 import { CurrentUser } from '../auth/decorator/user.decorator';
 import { UserBaseInfo } from '../auth/type/user-base-info.type';
 import { ApiTags } from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express';
 
 @Controller('users')
 @ApiTags('User API')
@@ -39,13 +43,15 @@ export class UserController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '유저 정보 수정' })
+  @ApiConsumes('multipart/form-data')
   @ApiOkResponse({ type: UserDto })
+  @UseInterceptors(FileInterceptor('profileImage'))
   async updateUser(
-    @Param('userId', ParseIntPipe) userId: number,
     @Body() payload: UpdateUserPayload,
     @CurrentUser() user: UserBaseInfo,
+    @UploadedFile() profileImageFile?: Express.Multer.File,
   ): Promise<UserDto> {
-    return this.userService.updateUser(userId, payload, user);
+    return this.userService.updateUser(payload, user, profileImageFile);
   }
 
   @Delete(':userId')

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -22,8 +22,20 @@ export class UserRepository {
         id: userId,
       },
       data: {
+        loginId: data.loginId ?? undefined,
+        gender: data.gender ?? undefined,
+        birthday: data.birthday ?? undefined,
+        profileImageUrl: data.profileImageUrl,
         name: data.name,
         email: data.email,
+        userCategories: data.interestCategories
+          ? {
+              deleteMany: {},
+              create: data.interestCategories.map((categoryId) => ({
+                categoryId,
+              })),
+            }
+          : undefined,
       },
     });
   }
@@ -112,5 +124,26 @@ export class UserRepository {
       ],
       readBookIds: user.userBooks.map((read) => read.bookId),
     }));
+  }
+
+  async isLoginIdExist(loginId: string): Promise<boolean> {
+    const user = await this.prisma.user.findFirst({
+      where: {
+        loginId,
+        deletedAt: null,
+      },
+    });
+
+    return !!user;
+  }
+
+  async isNameExist(name: string): Promise<boolean> {
+    const user = await this.prisma.user.findFirst({
+      where: {
+        name,
+        deletedAt: null,
+      },
+    });
+    return !!user;
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -10,10 +10,17 @@ import { UserBaseInfo } from '../auth/type/user-base-info.type';
 import { UserDto } from './dto/user.dto';
 import { UpdateUserPayload } from './payload/update-user.payload';
 import { UpdateUserData } from '../auth/type/update-user-data.type';
+import {
+  SupabaseService,
+  extractFilePathFromPublicUrl,
+} from '../common/services/supabase.service';
 
 @Injectable()
 export class UserService {
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly supabaseService: SupabaseService,
+  ) {}
 
   async getUserById(userId: number): Promise<UserDto> {
     const user = await this.userRepository.getUserById(userId);
@@ -26,30 +33,130 @@ export class UserService {
   }
 
   async updateUser(
-    userId: number,
     payload: UpdateUserPayload,
     user: UserBaseInfo,
+    profileImageFile?: Express.Multer.File,
   ): Promise<UserDto> {
-    const data = this.validateNullOf(payload);
-
-    const targetUser = await this.userRepository.getUserById(userId);
-
-    if (!targetUser) {
-      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    if (payload.loginId === null) {
+      throw new BadRequestException('로그인 ID는 null이 될 수 없습니다.');
+    }
+    if (payload.name === null) {
+      throw new BadRequestException('닉네임은 null이 될 수 없습니다.');
     }
 
-    if (userId !== user.id) {
-      throw new ForbiddenException('타인의 계정은 수정할 수 없습니다.');
+    if (payload.email === null) {
+      throw new BadRequestException('이메일은 null이 될 수 없습니다.');
     }
-
-    if (data.email) {
-      const isEmailExist = await this.userRepository.isEmailExist(data.email);
-
+    if (payload.loginId) {
+      if (payload.loginId === user.loginId) {
+        throw new BadRequestException('현재 사용 중인 로그인 ID와 동일합니다.');
+      }
+      const isLoginIdExist = await this.userRepository.isEmailExist(
+        payload.loginId,
+      );
+      if (isLoginIdExist) {
+        throw new ConflictException('이미 사용 중인 로그인 ID입니다.');
+      }
+    }
+    if (payload.email) {
+      if (payload.email === user.email) {
+        throw new BadRequestException('현재 사용 중인 이메일과 동일합니다.');
+      }
+      const isEmailExist = await this.userRepository.isEmailExist(
+        payload.email,
+      );
       if (isEmailExist) {
         throw new ConflictException('이미 사용 중인 이메일입니다.');
       }
     }
-    const updatedUser = await this.userRepository.updateUser(userId, data);
+    if (payload.name) {
+      if (payload.name === user.name) {
+        throw new BadRequestException('현재 사용 중인 닉네임과 동일합니다.');
+      }
+      const isNameExist = await this.userRepository.isNameExist(payload.name);
+
+      if (isNameExist) {
+        throw new ConflictException('이미 사용 중인 닉네임입니다.');
+      }
+    }
+    if (payload.birthday) {
+      if (payload.birthday > new Date()) {
+        throw new BadRequestException('생년월일이 유효하지 않습니다.');
+      }
+    }
+    if (payload.interestCategories) {
+      if (payload.interestCategories.length > 3) {
+        throw new BadRequestException(
+          '관심 카테고리는 최대 3개까지 선택 가능합니다.',
+        );
+      }
+    }
+    console.log(payload.interestCategories);
+
+    let profileImageUrl: string | undefined | null = undefined;
+    if (payload.removeProfileImage) {
+      if (profileImageFile) {
+        throw new BadRequestException(
+          '프로필 이미지 삭제 요청과 파일 업로드는 동시에 처리할 수 없습니다.',
+        );
+      }
+      if (!user.profileImageUrl) {
+        throw new BadRequestException('삭제할 프로필 이미지가 없습니다.');
+      }
+      const filePath = extractFilePathFromPublicUrl(user.profileImageUrl);
+      if (filePath) {
+        const { data: deleteResult, error: deleteError } =
+          await this.supabaseService.deleteImage('profile-images', filePath);
+
+        if (deleteError) {
+          console.error('이미지 삭제 실패:', deleteError.message);
+          throw new BadRequestException(
+            '기존 프로필 이미지 삭제에 실패했습니다.',
+          );
+        }
+        profileImageUrl = null;
+      }
+    }
+    if (user.profileImageUrl) {
+      const filePath = extractFilePathFromPublicUrl(user.profileImageUrl);
+      if (filePath) {
+        const { data: deleteResult, error: deleteError } =
+          await this.supabaseService.deleteImage('profile-images', filePath);
+
+        if (deleteError) {
+          console.error('이미지 삭제 실패:', deleteError.message);
+          throw new BadRequestException(
+            '기존 프로필 이미지 삭제에 실패했습니다.',
+          );
+        }
+      }
+    }
+    if (profileImageFile) {
+      const filePath = `profile-images/${user.id}/${profileImageFile.originalname}`;
+      const { data, error } = await this.supabaseService.uploadImage(
+        'profile-images',
+        filePath,
+        profileImageFile.buffer,
+      );
+      if (error) {
+        console.error('업로드 실패:', error.message);
+        throw new BadRequestException('업로드 실패: ' + error.message);
+      }
+      profileImageUrl = data?.path
+        ? this.supabaseService.getPublicUrl('profile-images', data.path)
+        : undefined;
+    }
+
+    const data: UpdateUserData = {
+      loginId: payload.loginId,
+      birthday: payload.birthday,
+      gender: payload.gender,
+      profileImageUrl,
+      email: payload.email,
+      name: payload.name,
+      interestCategories: payload.interestCategories,
+    };
+    const updatedUser = await this.userRepository.updateUser(user.id, data);
 
     return UserDto.from(updatedUser);
   }
@@ -60,21 +167,6 @@ export class UserService {
     }
 
     return this.userRepository.deleteUser(userId);
-  }
-
-  private validateNullOf(payload: UpdateUserPayload): UpdateUserData {
-    if (payload.name === null) {
-      throw new BadRequestException('이름은 null이 될 수 없습니다.');
-    }
-
-    if (payload.email === null) {
-      throw new BadRequestException('이메일은 null이 될 수 없습니다.');
-    }
-
-    return {
-      name: payload.name,
-      email: payload.email,
-    };
   }
   /*
   async getAllUsersWithBooks(): Promise<

--- a/yarn.lock
+++ b/yarn.lock
@@ -5263,6 +5263,11 @@ utils-merge@1.0.1, utils-merge@^1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"


### PR DESCRIPTION
1. 로그인을 아이디와 비밀번호의 조합으로 변경
2. 사용자 프로필에 프로필 이미지, 닉네임, 성별, 생년월일 추가
3. 이에 따른 회원가입 API 변경
4. 사용자 프로필 수정 API 변경 - 프로필 이미지의 경우 기본 프로필 이미지로 변경도 가능
5. 좋아하는 책 종류(장르) 최대 3가지 설정 가능. 이것도 회원가입 시에 입력받고 이후 수정 가능
6. 회원가입 시에 설정한 비밀번호를 재입력하는 기능 구현